### PR TITLE
Solution6: Expand Your Project with External Packages from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"version": "1.0.0",
 	"keywords": [ "freecodecamp", "backend", "api" ],
 	"dependencies": {
-		"express": "^4.14.0"
+		"express": "^4.14.0",
+		"@freecodecamp/example": "1.1.0"
 	},
 	"main": "server.js",
 	"scripts": {


### PR DESCRIPTION
Add version 1.1.0 of the @freecodecamp/example package to the dependencies field of your package.json file.

Note: @freecodecamp/example is a faux package used as a learning tool.

