### PR TITLE
Solution8: Use the Tilde-Character to Always Use the Latest Patch Vesion of a Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"keywords": [ "freecodecamp", "backend", "api" ],
 	"dependencies": {
 		"express": "^4.14.0",
-		"@freecodecamp/example": "1.2.13"
+		"@freecodecamp/example": "~1.2.13"
 	},
 	"main": "server.js",
 	"scripts": {


### PR DESCRIPTION
In the package.json file, your current rule for how npm may upgrade @freecodecamp/example is to use a specific version (1.2.13). But now, you want to allow the latest 1.2.x version.

Use the tilde (~) character to prefix the version of @freecodecamp/example in your dependencies, and allow npm to update it to any new patch release.

Note: The version numbers themselves should not be changed.