### PR TITLE
Solution9: Use the Caret-Character to Use the Latest Minor Version of a Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"keywords": [ "freecodecamp", "backend", "api" ],
 	"dependencies": {
 		"express": "^4.14.0",
-		"@freecodecamp/example": "~1.2.13"
+		"@freecodecamp/example": "^1.2.13"
 	},
 	"main": "server.js",
 	"scripts": {


### PR DESCRIPTION
Use the caret (^) to prefix the version of @freecodecamp/example in your dependencies and allow npm to update it to any new MINOR release.

Note: The version numbers themselves should not be changed.