### PR TITLE
Solution10: Remove a Package from Your Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
 	"version": "1.0.0",
 	"keywords": [ "freecodecamp", "backend", "api" ],
 	"dependencies": {
-		"express": "^4.14.0",
-		"@freecodecamp/example": "^1.2.13"
+		"express": "^4.14.0"
 	},
 	"main": "server.js",
 	"scripts": {


### PR DESCRIPTION
Remove the @freecodecamp/example package from your dependencies.

Note: Make sure you have the right amount of commas after removing it.